### PR TITLE
Classes simplification and ServiceItem's attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ require 'xymonclient/service'
 service = XymonClient::Service.new(['localhost:1984'],
   'name' => 'service1',
   'host' => 'myhost',
-  'header' => 'A sample header',
-  'footer' => 'A sample footer',
   'items' => {
     'ITEM1' => {
       'label' => 'Gauge Item 1',

--- a/lib/xymonclient/service.rb
+++ b/lib/xymonclient/service.rb
@@ -8,102 +8,104 @@ module XymonClient
   # Manage a Service, can contains multiple items to monitor
   class Service < XymonClient::Client
     attr_reader :name
-    attr_accessor :status
-    attr_reader :details
-    DEFAULT_DETAILS_TEMPLATE = 'Generated at <%= @timestamp %> ' \
-      "for <%= @lifetime %> \n<%= @header %>\n" \
+    attr_reader :status
+    attr_reader :items
+    attr_accessor :enabled
+    attr_accessor :lifetime
+
+    DEFAULT_DETAILS_TEMPLATE = \
+      "Generated at <%= @timestamp %> for <%= @lifetime %> \n" \
       '<% @items.each do |item| %>' \
       "&<%= item['status'] %> <%= item['label'] %>: <%= item['value'] %>\n" \
-      "<% end %>\n" \
-      "<%= @footer %>\n".freeze
+      "<% end %>\n".freeze
 
     def initialize(servers, config)
       super(servers)
-      @info = { 'items' => {} }
+      @items = {}
+      @current_state = 'purple'
       update_config(config)
     end
 
     def update_config(config)
       raise InvalidService if config.fetch('name', '') == ''
       raise InvalidService if config.fetch('host', '') == ''
-      @info['name'] = config['name']
-      @info['host'] = config['host']
-      @info['details_template'] = config.fetch(
+      @name = config['name']
+      @host = config['host']
+      @details_template = config.fetch(
         'details_template',
         DEFAULT_DETAILS_TEMPLATE
       )
-      @info['lifetime'] = config.fetch('lifetime', '30m')
-      @info['enabled'] = config.fetch('enabled', true)
-      @info['header'] = config.fetch('header', '')
-      @info['footer'] = config.fetch('footer', '')
+      @lifetime = config.fetch('lifetime', '30m')
+      @enabled = config.fetch('enabled', true)
       if config.fetch('items', {}).empty?
-        @info['items'] = {}
+        @items = {}
       else
-        _update_items_config(config)
+        _update_items_config(config['items'])
       end
-      @info['purple_item_status'] = config.fetch('purple_item_status', 'red')
-      @info['status'] = @info.fetch('status', config.fetch('status', 'purple'))
+      @purple_item_status = config.fetch('purple_item_status', 'red')
     end
 
     def update_item(name, value, attrs = {})
-      raise InvalidServiceItem unless @info['items'].include?(name)
-      @info['items'][name].value = value
-      @info['items'][name].attributes = attrs
+      raise InvalidServiceItem unless @items.include?(name)
+      @items[name].value = value
+      @items[name].attributes.merge!(attrs)
     end
 
     def status
-      return 'clear' unless @info['enabled']
-      items_status = @info['items'].map do |_key, value|
-        if value.info['status'] == 'purple'
-          @info['purple_item_status']
+      @timestamp = Time.now
+      return 'clear' unless @enabled
+      items_status = @items.map do |_key, value|
+        if value.status == 'purple'
+          @purple_item_status
         else
-          value.info['status']
+          value.status
         end
       end
-      @info['status'] = unless items_status.empty?
-                          if items_status.include?('red')
-                            'red'
-                          elsif items_status.include?('yellow') && \
-                                @status != 'red'
-                            'yellow'
-                          else
-                            'green'
-                          end
-                        end
+      @current_state = unless items_status.empty?
+                         if items_status.include?('red')
+                           'red'
+                         elsif items_status.include?('yellow') && \
+                               @current_state != 'red'
+                           'yellow'
+                         else
+                           'green'
+                         end
+                       end
       details = _details
-      super(
-        @info['host'],
-        @info['name'],
-        @info['status'],
-        details,
-        @info['lifetime']
-      )
-      [@info['status'], details]
+      super(@host, @name, @current_state, details, @lifetime)
+      [@current_state, details]
     end
 
     def enable
-      super(@info['host'], @info['name'])
+      super(@host, @name)
     end
 
     def disable(duration, message)
-      super(@info['host'], @info['name'], duration, message)
+      super(@host, @name, duration, message)
     end
 
     def board(fields = [])
-      super(@info['host'], @info['name'], fields)
+      super(@host, @name, fields)
     end
 
     def ack(duration, message)
-      super(@info['host'], @info['name'], duration, message)
+      super(@host, @name, duration, message)
     end
 
     private
 
     def _details
-      @info['timestamp'] = Time.now
-      context = @info.reject { |key, _value| key == 'items' }
-      context['items'] = @info['items'].map { |_key, value| value.info }
-      ERB.new(@info['details_template']).result(
+      context = {
+        'name' => @name,
+        'host' => @host,
+        'status' => @current_state,
+        'items' => {},
+        'enabled' => @enabled,
+        'lifetime' => @lifetime,
+        'timestamp' => @timestamp
+      }
+      context['items'] = @items.map { |_name, item| item.context }
+      ERB.new(@details_template).result(
         XymonClient::ERBContext.new(context).context
       )
     end
@@ -119,15 +121,15 @@ module XymonClient
       end
     end
 
-    def _update_items_config(config)
+    def _update_items_config(items)
       # cleanup old items and update old items
-      @info['items'].keep_if { |key, _value| config.fetch('items').key?(key) }
-      @info['items'].each do |item_name, item_value|
-        item_value.update_config(config['items'][item_name])
+      @items.keep_if { |key, _value| items.key?(key) }
+      @items.each do |item_name, item_value|
+        item_value.update_config(items[item_name])
       end
       # add new items
-      config['items'].each do |item_name, item_config|
-        @info['items'][item_name] = _create_serviceitem(item_config)
+      items.each do |item_name, item_config|
+        @items[item_name] = _create_serviceitem(item_config)
       end
     end
   end

--- a/lib/xymonclient/service.rb
+++ b/lib/xymonclient/service.rb
@@ -45,9 +45,10 @@ module XymonClient
       @info['status'] = @info.fetch('status', config.fetch('status', 'purple'))
     end
 
-    def update_item(name, value)
+    def update_item(name, value, attrs = {})
       raise InvalidServiceItem unless @info['items'].include?(name)
       @info['items'][name].value = value
+      @info['items'][name].attributes = attrs
     end
 
     def status

--- a/lib/xymonclient/serviceitem.rb
+++ b/lib/xymonclient/serviceitem.rb
@@ -6,6 +6,7 @@ module XymonClient
   # Manage an item to monitor
   class ServiceItem
     attr_accessor :value
+    attr_accessor :attributes
     attr_reader :info
 
     def initialize(config)
@@ -17,7 +18,8 @@ module XymonClient
         'enabled' => config.fetch('enabled', true),
         'status' => 'purple',
         'lifetime' => config.fetch('lifetime', '30m'),
-        'time' => Time.at(0)
+        'time' => Time.at(0),
+        'attributes' => config.fetch('attributes', {})
       }
     end
 
@@ -29,6 +31,14 @@ module XymonClient
 
     def value
       @info['value']
+    end
+
+    def attributes=(attrs)
+      @info['attributes'] = attrs
+    end
+
+    def attributes
+      @info['attributes']
     end
 
     def status

--- a/lib/xymonclient/serviceitem.rb
+++ b/lib/xymonclient/serviceitem.rb
@@ -7,52 +7,56 @@ module XymonClient
   class ServiceItem
     attr_accessor :value
     attr_accessor :attributes
-    attr_reader :info
+    attr_accessor :enabled
+    attr_accessor :description
+    attr_accessor :lifetime
+    attr_accessor :label
+    attr_reader :status
+    attr_reader :time
 
     def initialize(config)
       raise InvalidServiceItemName if config.fetch('label', '') == ''
-      @info = {
-        'label' => config['label'],
-        'type' => config['type'],
-        'description' => config.fetch('description', ''),
-        'enabled' => config.fetch('enabled', true),
-        'status' => 'purple',
-        'lifetime' => config.fetch('lifetime', '30m'),
-        'time' => Time.at(0),
-        'attributes' => config.fetch('attributes', {})
-      }
+      @label = config['label']
+      @description = config.fetch('description', '')
+      @enabled = config.fetch('enabled', true)
+      @lifetime = config.fetch('lifetime', '30m')
+      @time = Time.at(0)
+      @threshold = config.fetch('threshold', {})
+      @attributes = config.fetch('attributes', {})
     end
 
     def value=(value)
-      @info['value'] = value
-      @info['time'] = Time.now
+      @value = value
+      @time = Time.now
       status
     end
 
-    def value
-      @info['value']
-    end
-
-    def attributes=(attrs)
-      @info['attributes'] = attrs
-    end
-
-    def attributes
-      @info['attributes']
-    end
-
     def status
-      @info['status'] = \
-        if !@info['enabled']
+      @status = \
+        if !@enabled
           'clear'
-        elsif Time.now - @info['time'] > \
-              XymonClient.timestring_to_time(@info['lifetime'])
+        elsif Time.now - @time > \
+              XymonClient.timestring_to_time(@lifetime)
           'purple'
-        elsif XymonClient.valid_status?(@info['value'])
-          @info['value']
+        elsif XymonClient.valid_status?(@value)
+          @value
         else
           'red'
         end
+    end
+
+    def context
+      {
+        'label' => @label,
+        'description' => @description,
+        'enabled' => @enabled,
+        'lifetime' => @lifetime,
+        'timestamp' => @timestamp,
+        'threshold' => @threshold,
+        'attributes' => @attributes,
+        'status' => @status,
+        'value' => @value
+      }
     end
   end
 
@@ -60,23 +64,22 @@ module XymonClient
   class ServiceItemGauge < ServiceItem
     def initialize(config)
       super(config)
-      @info['threshold'] = config.fetch('threshold', {})
-      @info['nan_status'] = config.fetch('nan_status', 'green')
+      @nan_status = config.fetch('nan_status', 'green')
     end
 
     def status
-      @info['status'] = \
-        if !@info['enabled']
+      @status = \
+        if !@enabled
           'clear'
-        elsif Time.now - @info['time'] > \
-              XymonClient.timestring_to_time(@info['lifetime'])
+        elsif Time.now - @time > \
+              XymonClient.timestring_to_time(@lifetime)
           'purple'
         elsif value.instance_of?(Float) && value.nan?
-          @info['threshold'].fetch('nan_status', 'red')
-        elsif @info['threshold'].key?('critical') && \
+          @threshold.fetch('nan_status', 'red')
+        elsif @threshold.key?('critical') && \
               _threshold_reached?('critical')
           'red'
-        elsif @info['threshold'].key?('warning') && \
+        elsif @threshold.key?('warning') && \
               _threshold_reached?('warning')
           'yellow'
         else
@@ -84,40 +87,41 @@ module XymonClient
         end
     end
 
+    def context
+      {
+        'nan_status' => @nan_status
+      }.merge(super)
+    end
+
     private
 
     def _threshold_reached?(threshold)
-      case @info['threshold'].fetch('order', '<')
+      case @threshold.fetch('order', '<')
       when '<'
-        @info['value'] < @info['threshold'][threshold]
+        @value < @threshold[threshold]
       when '>'
-        @info['value'] > @info['threshold'][threshold]
+        @value > @threshold[threshold]
       when '<='
-        @info['value'] <= @info['threshold'][threshold]
+        @value <= @threshold[threshold]
       when '>='
-        @info['value'] >= @info['threshold'][threshold]
+        @value >= @threshold[threshold]
       end
     end
   end
 
   ##
   class ServiceItemString < ServiceItem
-    def initialize(config)
-      super(config)
-      @info['threshold'] = config.fetch('threshold', {})
-    end
-
     def status
-      @info['status'] = \
-        if !@info['enabled']
+      @status = \
+        if !@enabled
           'clear'
-        elsif Time.now - @info['time'] > \
-              XymonClient.timestring_to_time(@info['lifetime'])
+        elsif Time.now - @time > \
+              XymonClient.timestring_to_time(@lifetime)
           'purple'
-        elsif @info['threshold'].key?('critical') && \
+        elsif @threshold.key?('critical') && \
               _threshold_reached?('critical')
           'red'
-        elsif @info['threshold'].key?('warning') && \
+        elsif @threshold.key?('warning') && \
               _threshold_reached?('warning')
           'yellow'
         else
@@ -128,14 +132,14 @@ module XymonClient
     private
 
     def _threshold_reached?(threshold)
-      inclusive = @info['threshold'].fetch('inclusive', true)
-      values = @info['value']
+      inclusive = @threshold.fetch('inclusive', true)
+      values = @value
       if values.instance_of?(Array)
         value_is_included = values.any? do |value|
-          @info['threshold'][threshold].include?(value)
+          @threshold[threshold].include?(value)
         end
       else
-        value_is_included = @info['threshold'][threshold].include?(values)
+        value_is_included = @threshold[threshold].include?(values)
       end
       (inclusive && value_is_included) || (!inclusive && !value_is_included)
     end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -9,8 +9,6 @@ describe XymonClient do
         ['localhost'],
         'name' => 'service1',
         'host' => 'myhost',
-        'header' => 'A sample header',
-        'footer' => 'A sample footer',
         'items' => {
           'ITEM1' => {
             'label' => 'Gauge Item 1',
@@ -41,7 +39,7 @@ describe XymonClient do
       # rubocop:disable LineLength
       expect(service.status[0]).to eq('red')
       expect(service.status[1]).to match(
-        /Generated at .* for 30m \nA sample header\n&red Gauge Item 1: 3\n&green String Item 2: all is Ok !\n\nA sample footer/
+        /Generated at .* for 30m \n&red Gauge Item 1: 3\n&green String Item 2: all is Ok !\n\n/
       )
       # rubocop:enable LineLength
     end

--- a/spec/serviceitem_spec.rb
+++ b/spec/serviceitem_spec.rb
@@ -50,7 +50,17 @@ describe XymonClient do
 
   describe XymonClient::ServiceItemString do
     describe 'inclusive' do
-      let(:config) { { 'label' => 'Item 1', 'threshold' => {'inclusive' => true, 'critical' => ['foo'], 'warning' => ['bar']}} }
+      let(:config) do
+        {
+          'label' => 'Item 1',
+          'threshold' => {
+            'inclusive' => true,
+            'critical' => ['foo'],
+            'warning' => ['bar']
+          }
+        }
+      end
+
       it 'should return red status when value is included in critical threshold' do
         item = described_class.new(config)
         item.value = 'foo'
@@ -71,7 +81,17 @@ describe XymonClient do
     end
 
     describe 'exclusive' do
-      let(:config) { { 'label' => 'Item 1', 'threshold' => {'inclusive' => false, 'critical' => ['foo'], 'warning' => ['bar']}} }
+      let(:config) do
+        {
+          'label' => 'Item 1',
+          'threshold' => {
+            'inclusive' => false,
+            'critical' => ['foo'],
+            'warning' => ['bar']
+          }
+        }
+      end
+
       it 'should return red status when "foo" is not included in critical threshold' do
         item = described_class.new(config)
         item.value = ['bar']
@@ -86,7 +106,7 @@ describe XymonClient do
 
       it 'should return green status when all values are included in critical/warning threshold' do
         item = described_class.new(config)
-        item.value = ['foo', 'bar']
+        item.value = %w(foo bar)
         expect(item.status).to eq('green')
       end
     end


### PR DESCRIPTION
# Replace hash of parameters with real classe's accessors
```ruby
ServiceItem['info']['label']
```
become
```ruby
ServiceItem.label
```
# Add extra attributes to ServiceItem, dynamic updates and access to them from template
```ruby
test_attributes = XymonClient::Service.new(
          ['localhost'],
          'name' => 'service1',
          'host' => 'myhost',
          'details_template' => '<% @items.each do |item| %>' \
                "&<%= item['status'] %> " \
                "<%= item['label'] %>: <%= item['value'] %>\n" \
                "foo : <%= item['attributes']['foo'] %>\n" \
                "<% end %>\n",
          'items' => {
            'ITEM1' => {
              'label' => 'String Item 2',
              'type' => 'string',
              'threshold' => {
                'inclusive' => false,
                'critical' => ['all is Ok !']
              }
            }
          }
        )
test_attributes.update_item('ITEM1', 'all is KO !', 'foo' => 'bar')
```
xymon's output : 
```
&red String Item 2: all is KO !
foo : bar
```
# Remove unnecessary Service parameters `header` and `footer`
details template could be changed directly